### PR TITLE
desktop-exports: Add $ARCH-based paths

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -284,9 +284,11 @@ fi
 # GI repository
 prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/girepository-1.0"
+prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gjs/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/$ARCH/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/girepository-1.0"
+prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/$ARCH/gjs/girepository-1.0"
 prepend_dir GI_TYPELIB_PATH "$SNAP/usr/lib/gjs/girepository-1.0"
 
 # Keep an array of data dirs, for looping through them


### PR DESCRIPTION
Private gjs typelibs are installed in `/snap/gnome-42-2204-sdk/current/usr/lib/x86_64-linux-gnu/gjs/girepository-1.0` so we should include those.

However gjs should be compiled in a way that this is not needed.